### PR TITLE
Fix for upstream changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://sfackler.github.io/rust-postgres-array/doc/postgres_arr
 
 [dependencies]
 postgres = "0.7.1"
-byteorder = "0.2.11"
+byteorder = "0.3"
 
 [dev-dependencies]
 rustc-serialize = "0.3"

--- a/src/impls/mod.rs
+++ b/src/impls/mod.rs
@@ -28,7 +28,7 @@ impl<T> FromSql for ArrayBase<Option<T>> where T: FromSql {
         let nele = if dim_info.len() == 0 {
             0
         } else {
-            dim_info.iter().map(|info| info.len as usize).product()
+            dim_info.iter().map(|info| info.len).product()
         };
 
         let mut elements = Vec::with_capacity(nele);

--- a/src/impls/mod.rs
+++ b/src/impls/mod.rs
@@ -19,7 +19,7 @@ impl<T> FromSql for ArrayBase<Option<T>> where T: FromSql {
         let _element_type: Oid = try!(raw.read_u32::<BigEndian>());
 
         let mut dim_info = Vec::with_capacity(ndim);
-        for _ in range(0, ndim) {
+        for _ in (0..ndim) {
             dim_info.push(DimensionInfo {
                 len: try!(raw.read_u32::<BigEndian>()) as usize,
                 lower_bound: try!(raw.read_i32::<BigEndian>()) as isize,
@@ -32,7 +32,7 @@ impl<T> FromSql for ArrayBase<Option<T>> where T: FromSql {
         };
 
         let mut elements = Vec::with_capacity(nele);
-        for _ in range(0, nele) {
+        for _ in (0..nele) {
             let len = try!(raw.read_i32::<BigEndian>());
             if len < 0 {
                 elements.push(None);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! Multi-dimensional arrays with per-dimension specifiable lower bounds
 #![doc(html_root_url="https://sfackler.github.io/rust-postgres-array/doc")]
-#![feature(core, io)]
+#![feature(core)]
 
 #[macro_use(to_sql_checked)]
 extern crate postgres;
@@ -362,7 +362,7 @@ mod tests {
     }
 
     #[test]
-    #[should_fail]
+    #[should_panic]
     fn test_get_2d_fail() {
         let mut a = ArrayBase::from_vec(vec!(0i32, 1, 2), -1);
         a.wrap(1);
@@ -370,7 +370,7 @@ mod tests {
     }
 
     #[test]
-    #[should_fail]
+    #[should_panic]
     fn test_2d_slice_range_fail_low() {
         let mut a = ArrayBase::from_vec(vec!(0i32, 1, 2), -1);
         a.wrap(1);
@@ -378,7 +378,7 @@ mod tests {
     }
 
     #[test]
-    #[should_fail]
+    #[should_panic]
     fn test_2d_slice_range_fail_high() {
         let mut a = ArrayBase::from_vec(vec!(0i32, 1, 2), -1);
         a.wrap(1);
@@ -396,14 +396,14 @@ mod tests {
     }
 
     #[test]
-    #[should_fail]
+    #[should_panic]
     fn test_push_move_wrong_lower_bound() {
         let mut a = ArrayBase::from_vec(vec!(1i32), -1);
         a.push_move(ArrayBase::from_vec(vec!(2), 0));
     }
 
     #[test]
-    #[should_fail]
+    #[should_panic]
     fn test_push_move_wrong_dims() {
         let mut a = ArrayBase::from_vec(vec!(1i32), -1);
         a.wrap(1);
@@ -411,7 +411,7 @@ mod tests {
     }
 
     #[test]
-    #[should_fail]
+    #[should_panic]
     fn test_push_move_wrong_dim_count() {
         let mut a = ArrayBase::from_vec(vec!(1i32), -1);
         a.wrap(1);
@@ -472,14 +472,14 @@ mod tests {
     }
 
     #[test]
-    #[should_fail]
+    #[should_panic]
     fn test_base_overslice() {
         let a = ArrayBase::from_vec(vec!(1i32), 0);
         a.slice(0);
     }
 
     #[test]
-    #[should_fail]
+    #[should_panic]
     fn test_slice_overslice() {
         let mut a = ArrayBase::from_vec(vec!(1i32), 0);
         a.wrap(0);


### PR DESCRIPTION
`range(start, stop)` was replaced with `(start..stop)`, and the 0.2 `byteorder` crate dependency no longer builds.

This pull request replaces `range` with the new syntax, and updates `byteorder` to 0.3.

The second commit fixes all current compiler warnings.