### PR TITLE
Add .extract() for extracting underlying Vec

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -144,6 +144,12 @@ impl<T> Array<T> {
     pub fn iter_mut<'a>(&'a mut self) -> IterMut<'a, T> {
         IterMut { inner: self.data.iter_mut() }
     }
+
+    /// Returns the underlying data vector for this Array in the
+    /// higher-dimensional equivalent of row-major order.
+    pub fn extract(self) -> Vec<T> {
+        self.data
+    }
 }
 
 /// A trait implemented by types that can index into an `Array`.

--- a/src/array.rs
+++ b/src/array.rs
@@ -147,7 +147,7 @@ impl<T> Array<T> {
 
     /// Returns the underlying data vector for this Array in the
     /// higher-dimensional equivalent of row-major order.
-    pub fn extract(self) -> Vec<T> {
+    pub fn into_inner(self) -> Vec<T> {
         self.data
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,16 @@ mod tests {
     }
 
     #[test]
+    fn test_extract() {
+        let a = Array::from_vec(vec![0i32, 1, 2], -1);
+        let a = a.extract();
+        assert_eq!(a.len(), 3);
+        assert_eq!(0, a[0]);
+        assert_eq!(1, a[1]);
+        assert_eq!(2, a[2]);
+    }
+
+    #[test]
     fn test_2d_slice_get() {
         let mut a = Array::from_vec(vec![0i32, 1, 2], -1);
         a.wrap(1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,9 +49,9 @@ mod tests {
     }
 
     #[test]
-    fn test_extract() {
+    fn test_into_inner() {
         let a = Array::from_vec(vec![0i32, 1, 2], -1);
-        let a = a.extract();
+        let a = a.into_inner();
         assert_eq!(a.len(), 3);
         assert_eq!(0, a[0]);
         assert_eq!(1, a[1]);


### PR DESCRIPTION
When fetching rows with `rust-postgres`, turning a Postgres Array from a returned row into a Rust Vec is not quite straightforward, and requirings going to an `IntoIterator` and back:
```rust
row.get::<_, Array<_>>(0).into_iter().collect()
```
This adds overhead, and could even add an allocation in the worst case. A better solution would be to provide a method for directly extracting the underlying Vec of a row.

This PR adds `Array::extract()`, which does just that. It consumes the `Array`, and returns the underlying `Vec`, allowing the code above to be expressed as:
```rust
row.get::<_, Array<_>>(0).extract()
```